### PR TITLE
README: Already Onboarded Subscriptions Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,15 @@ To enable plans using this module, follow these steps based on the subscription 
 * To disable a specific plan, remove the plan name from mdc_plans_list var and execute `terraform apply` command.
 
 ### Already onboarded subscription
-If you've already onboarded your Azure Subscription to Microsoft Defender for Cloud plans, you have several options:
-1. **Start Fresh**: You can choose to destroy your current Terraform environment and begin anew.
-2. **Import Existing Resources**: Utilize [Terraform import](https://developer.hashicorp.com/terraform/cli/import) to seamlessly integrate existing resources into Terraform management.
-3. **Manage Multiple Terraform States**: Maintain your current state and create a new one for this module, allowing for efficient resource management.
-4. **Manual Cleanup**: Optionally, manually disable plans and delete the extensions and their associated policies.
+We recommend managing the entire onboarding process with our module. If you've already onboarded your Azure Subscription to Microsoft Defender for Cloud plans, you have several options:
+
+#### Azure Defender Plans UI Portal
+* **Manual Cleanup**: Manually toggle off the status of all MDC plans.
+
+#### Terraform CLI
+* **Start Fresh**: You can choose to destroy your current Terraform environment and begin anew.
+* **Import Existing Resources**: Utilize [Terraform import](https://developer.hashicorp.com/terraform/cli/import) to seamlessly integrate existing resources into Terraform management.
+* **Manage Multiple Terraform States**: Maintain your current state and create a new one for this module, allowing for efficient resource management.
 
 ## Contributing
 ### Configurations

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 -> **NOTE:** This module is still in development and we are currently in a preview version. As such, any usage of the module is at your own risk and responsibility.
 
--> **NOTE:** When running the module, your subscription should not already be onboarding to MDC. Please refer to the [Already onboarded subscription](#Already-onboarded-subscription) section if you have already completed the onboarding process.
+-> **NOTE:** When running the module, your subscription should not already be onboarded to MDC. If you have already completed the onboarding process, please refer to the  [Onboarded Azure Subscription](#Onboarded-Azure-Subscription) section.
 
 ~> **NOTE:** Deletion of the resource will reset the pricing tier to `Free`
 
@@ -48,7 +48,7 @@ To enable plans using this module, follow these steps based on the subscription 
 * To disable all plans execute `terraform destroy` command.
 * To disable a specific plan, remove the plan name from mdc_plans_list var and execute `terraform apply` command.
 
-### Already onboarded subscription
+### Onboarded Azure Subscription
 We recommend managing the entire onboarding process with our module. If you've already onboarded your Azure Subscription to Microsoft Defender for Cloud plans, you have several options:
 
 #### Azure Defender Plans UI Portal

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 -> **NOTE:** This module is still in development and we are currently in a preview version. As such, any usage of the module is at your own risk and responsibility.
 
+-> **NOTE:** When running the module, your subscription should not already be onboarding to MDC. Please refer to the [Already onboarded subscription](#Already-onboarded-subscription) section if you have already completed the onboarding process.
+
 ~> **NOTE:** Deletion of the resource will reset the pricing tier to `Free`
 
 
@@ -45,6 +47,13 @@ To enable plans using this module, follow these steps based on the subscription 
 
 * To disable all plans execute `terraform destroy` command.
 * To disable a specific plan, remove the plan name from mdc_plans_list var and execute `terraform apply` command.
+
+### Already onboarded subscription
+If you've already onboarded your Azure Subscription to Microsoft Defender for Cloud plans, you have several options:
+1. **Start Fresh**: You can choose to destroy your current Terraform environment and begin anew.
+2. **Import Existing Resources**: Utilize [Terraform import](https://developer.hashicorp.com/terraform/cli/import) to seamlessly integrate existing resources into Terraform management.
+3. **Manage Multiple Terraform States**: Maintain your current state and create a new one for this module, allowing for efficient resource management.
+4. **Manual Cleanup**: Optionally, manually disable plans and delete the extensions and their associated policies.
 
 ## Contributing
 ### Configurations


### PR DESCRIPTION
I have updated the README with a new explanation of the available choices if you have already onboarded your Azure subscription to Microsoft Defender for Cloud plans.