### PR TITLE
Add `ignore_changes` to telemetry resource

### DIFF
--- a/examples/single_subscription/versions.tf
+++ b/examples/single_subscription/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     modtm = {
       source  = "Azure/modtm"
-      version = ">= 0.1.7, < 1.0"
+      version = ">= 0.1.8, < 1.0"
     }
   }
 }

--- a/module_telemetry.tf
+++ b/module_telemetry.tf
@@ -1,7 +1,10 @@
 resource "modtm_telemetry" "this" {
   tags = {
-
     avm_yor_name  = "this"
     avm_yor_trace = "b7642d6f-c1b3-45da-8837-9a64e8b7396e"
+  }
+
+  lifecycle {
+    ignore_changes = [nonce]
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     modtm = {
       source  = "Azure/modtm"
-      version = ">= 0.1.7, < 1.0"
+      version = ">= 0.1.8, < 1.0"
     }
   }
 }


### PR DESCRIPTION
## Describe your changes

This pr added `ignore_changes` setting to the `modtm_telemetry` resource and updated provider's constraint, so the module's users won't see any terraform drift caused by change on `nonce` attribute.

## Issue number

#000

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

