### PR TITLE
Add a setup step to clean all potential existing plans before test

### DIFF
--- a/test/e2e/terraform_test.go
+++ b/test/e2e/terraform_test.go
@@ -1,10 +1,14 @@
 package e2e
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	test_helper "github.com/Azure/terraform-module-test-helper"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	teststructure "github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,11 +25,18 @@ func TestExamples_single_subscription(t *testing.T) {
 		"StorageAccounts",
 		"Api",
 	}
-	test_helper.RunE2ETest(t, "../../", "examples/single_subscription", terraform.Options{
+	vars := map[string]interface{}{
+		"mdc_plans_list": plans,
+	}
+
+	moduleRoot := "../../"
+	examplePath := "examples/single_subscription"
+
+	cleanAllExistingPlans(t, moduleRoot, examplePath, plans, vars)
+
+	test_helper.RunE2ETest(t, moduleRoot, examplePath, terraform.Options{
 		Upgrade: true,
-		Vars: map[string]interface{}{
-			"mdc_plans_list": plans,
-		},
+		Vars:    vars,
 	}, func(t *testing.T, output test_helper.TerraformOutput) {
 		pricingIds := output["subscription_pricing_id"].(map[string]any)
 		for _, p := range plans {
@@ -33,4 +44,28 @@ func TestExamples_single_subscription(t *testing.T) {
 			assert.Regexp(t, "/subscriptions/.+/providers/Microsoft.Security/pricings/.+", pricingIds[p])
 		}
 	})
+}
+
+func cleanAllExistingPlans(t *testing.T, moduleRoot string, examplePath string, plans []string, vars map[string]interface{}) {
+	subId := os.Getenv("ARM_SUBSCRIPTION_ID")
+	if subId == "" {
+		return
+	}
+	tmpFolder := teststructure.CopyTerraformFolderToTemp(t, moduleRoot, examplePath)
+	defer func() {
+		_ = os.RemoveAll(tmpFolder)
+	}()
+	opt := &terraform.Options{
+		TerraformDir: tmpFolder,
+		Vars:         vars,
+		NoColor:      true,
+		NoStderr:     true,
+		Logger:       logger.Default,
+	}
+	terraform.Init(t, opt)
+	for _, p := range plans {
+		command := terraform.RunTerraformCommand(t, opt, "import", fmt.Sprintf(`module.mdc_plans_enable.azurerm_security_center_subscription_pricing.asc_plans["%s"]`, p), fmt.Sprintf(`/subscriptions/%s/providers/Microsoft.Security/pricings/%s`, subId, p))
+		println(command)
+	}
+	terraform.Destroy(t, opt)
 }

--- a/test/e2e/terraform_test.go
+++ b/test/e2e/terraform_test.go
@@ -49,7 +49,7 @@ func TestExamples_single_subscription(t *testing.T) {
 func cleanAllExistingPlans(t *testing.T, moduleRoot string, examplePath string, plans []string, vars map[string]interface{}) {
 	subId := os.Getenv("ARM_SUBSCRIPTION_ID")
 	if subId == "" {
-		return
+		t.Skip("you need environment variable `ARM_SUBSCRIPTION_ID` to run this test.")
 	}
 	tmpFolder := teststructure.CopyTerraformFolderToTemp(t, moduleRoot, examplePath)
 	defer func() {


### PR DESCRIPTION
## Describe your changes

This module's e2e test failed sometimes because of unwanted existing plans. This pr introduced a cleanup step before e2e test to avoid such test failure.

## Issue number

#000

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

