### PR TITLE
Rename Policies for Containers, SQL Server Virtual Machines, and Virtual Machines to Prevent Conflicts

### DIFF
--- a/extensions_containers.tf
+++ b/extensions_containers.tf
@@ -1,46 +1,46 @@
 locals {
   container_policies = {
-    mdc-containers-kubernetes1-autoprovisioning = {
+    mdc-containers-kubernetes1-autoprovisioning-containers = {
       definition_display_name = "Configure Azure Arc enabled Kubernetes clusters to install the Azure Policy extension"
     }
-    mdc-containers-kubernetes2-autoprovisioning = {
+    mdc-cmdc-containers-kubernetes2-autoprovisioning-containers = {
       definition_display_name = "Deploy Azure Policy Add-on to Azure Kubernetes Service clusters"
     }
-    mdc-containers_aks_autoprovisioning = {
+    mdc-containers_aks_autoprovisioning-containers = {
       definition_display_name = "Configure Azure Kubernetes Service clusters to enable Defender profile"
     }
-    mdc-containers-arc-autoprovisioning = {
+    mdc-containers-arc-autoprovisioning-containers = {
       definition_display_name = "[Preview]: Configure Azure Arc enabled Kubernetes clusters to install Microsoft Defender for Cloud extension"
     }
   }
   container_roles = {
     containers-kubernetes1-role-1 = {
       name   = "Kubernetes Extension Contributor"
-      policy = "mdc-containers-kubernetes1-autoprovisioning"
+      policy = "mdc-containers-kubernetes1-autoprovisioning-containers"
     }
     containers-kubernetes2-role-1 = {
       name   = "Azure Kubernetes Service Contributor Role"
-      policy = "mdc-containers-kubernetes2-autoprovisioning"
+      policy = "mdc-cmdc-containers-kubernetes2-autoprovisioning-containers"
     }
     containers-kubernetes2-role-2 = {
       name   = "Azure Kubernetes Service Policy Add-on Deployment"
-      policy = "mdc-containers-kubernetes2-autoprovisioning"
+      policy = "mdc-cmdc-containers-kubernetes2-autoprovisioning-containers"
     }
     containers-aks-role-1 = {
       name   = "Log Analytics Contributor"
-      policy = "mdc-containers_aks_autoprovisioning"
+      policy = "mdc-containers_aks_autoprovisioning-containers"
     }
     containers-aks-role-2 = {
       name   = "Contributor"
-      policy = "mdc-containers_aks_autoprovisioning"
+      policy = "mdc-containers_aks_autoprovisioning-containers"
     }
     containers-arc-role-1 = {
       name   = "Log Analytics Contributor"
-      policy = "mdc-containers-arc-autoprovisioning"
+      policy = "mdc-containers-arc-autoprovisioning-containers"
     }
     containers-arc-role-2 = {
       name   = "Contributor"
-      policy = "mdc-containers-arc-autoprovisioning"
+      policy = "mdc-containers-arc-autoprovisioning-containers"
     }
   }
 }

--- a/extensions_sql_server_virtual_machines.tf
+++ b/extensions_sql_server_virtual_machines.tf
@@ -1,20 +1,20 @@
 locals {
   log_analytics_policies = {
-    mdc-log-analytics-arc1-autoprovisioning = {
+    mdc-log-analytics-arc1-autoprovisioning-sql = {
       definition_display_name = "[Preview]: Configure Azure Arc-enabled Windows machines with Log Analytics agents connected to default Log Analytics workspace"
     }
-    mdc-log-analytics-arc2-autoprovisioning = {
+    mdc-log-analytics-arc2-autoprovisioning-sql = {
       definition_display_name = "[Preview]: Configure Azure Arc-enabled Linux machines with Log Analytics agents connected to default Log Analytics workspace"
     }
   }
   log_analytics_roles = {
     sql-server-virtual-machines-arc1-role-1 = {
       name   = "Contributor"
-      policy = "mdc-log-analytics-arc1-autoprovisioning"
+      policy = "mdc-log-analytics-arc1-autoprovisioning-sql"
     }
     sql-server-virtual-machines-arc2-role-1 = {
       name   = "Contributor"
-      policy = "mdc-log-analytics-arc2-autoprovisioning"
+      policy = "mdc-log-analytics-arc2-autoprovisioning-sql"
     }
   }
   sql_server_virtual_machines_enabled = contains(local.final_plans_list, "SqlServerVirtualMachines") && !contains(var.mdc_plans_list, "VirtualMachines")

--- a/extensions_virtual_machines.tf
+++ b/extensions_virtual_machines.tf
@@ -5,28 +5,28 @@ locals {
     }
   })
   virtual_machine_policies = {
-    mdc-va-autoprovisioning = {
+    mdc-va-autoprovisioning-vm = {
       definition_display_name = "Configure machines to receive a vulnerability assessment provider"
     }
-    mdc-log-analytics-arc1-autoprovisioning = {
+    mdc-log-analytics-arc1-autoprovisioning-vm = {
       definition_display_name = "[Preview]: Configure Azure Arc-enabled Windows machines with Log Analytics agents connected to default Log Analytics workspace"
     }
-    mdc-log-analytics-arc2-autoprovisioning = {
+    mdc-log-analytics-arc2-autoprovisioning-vm = {
       definition_display_name = "[Preview]: Configure Azure Arc-enabled Linux machines with Log Analytics agents connected to default Log Analytics workspace"
     }
   }
   virtual_machine_roles = {
     virtual-machines-va-role-1 = {
       name   = "Security Admin"
-      policy = "mdc-va-autoprovisioning"
+      policy = "mdc-va-autoprovisioning-vm"
     }
     virtual-machines-arc1-role-1 = {
       name   = "Contributor"
-      policy = "mdc-log-analytics-arc1-autoprovisioning"
+      policy = "mdc-log-analytics-arc1-autoprovisioning-vm"
     }
     virtual-machines-arc2-role-1 = {
       name   = "Contributor"
-      policy = "mdc-log-analytics-arc2-autoprovisioning"
+      policy = "mdc-log-analytics-arc2-autoprovisioning-vm"
     }
   }
 }
@@ -46,7 +46,7 @@ resource "azurerm_subscription_policy_assignment" "vm" {
   subscription_id      = data.azurerm_subscription.current.id
   display_name         = each.value.definition_display_name
   location             = var.location
-  parameters           = each.key == "mdc-va-autoprovisioning" ? local.va_type : null
+  parameters           = each.key == "mdc-va-autoprovisioning-vm" ? local.va_type : null
 
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
This update renames policies for **containers**, **SQL Server virtual machines**, and **virtual machines** to avoid naming conflicts and ensure consistent policy application