### PR TITLE
Add the varaible storage_accounts_malware_scan_cap_gb_per_month

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "azurerm_security_center_subscription_pricing" "asc_plans" {
     content {
       name = "OnUploadMalwareScanning"
       additional_extension_properties = {
-        CapGBPerMonthPerStorageAccount = "5000"
+        CapGBPerMonthPerStorageAccount = var.storage_accounts_malware_scan_cap_gb_per_month
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -71,3 +71,9 @@ variable "tracing_tags_prefix" {
   description = "Default prefix for generated tracing tags"
   nullable    = false
 }
+
+variable "storage_accounts_malware_scan_cap_gb_per_month" {
+  type        = string
+  default     = "5000"
+  description = "(Optional) Sets the maximum GB limit for malware scanning on uploaded files per storage account per month"
+}


### PR DESCRIPTION
Adds storage_accounts_malware_scan_cap_gb_per_month to set CapGBPerMonthPerStorageAccount in the OnUploadMalwareScanning extension.