### PR TITLE
Remove deprecated Log Analytics agent

### DIFF
--- a/extensions_virtual_machines.tf
+++ b/extensions_virtual_machines.tf
@@ -8,30 +8,16 @@ locals {
     mdc-va-autoprovisioning-vm = {
       definition_display_name = "Configure machines to receive a vulnerability assessment provider"
     }
-    mdc-log-analytics-arc1-autoprovisioning-vm = {
-      definition_display_name = "[Preview]: Configure Azure Arc-enabled Windows machines with Log Analytics agents connected to default Log Analytics workspace"
-    }
-    mdc-log-analytics-arc2-autoprovisioning-vm = {
-      definition_display_name = "[Preview]: Configure Azure Arc-enabled Linux machines with Log Analytics agents connected to default Log Analytics workspace"
-    }
   }
   virtual_machine_roles = {
     virtual-machines-va-role-1 = {
       name   = "Security Admin"
       policy = "mdc-va-autoprovisioning-vm"
     }
-    virtual-machines-arc1-role-1 = {
-      name   = "Contributor"
-      policy = "mdc-log-analytics-arc1-autoprovisioning-vm"
-    }
-    virtual-machines-arc2-role-1 = {
-      name   = "Contributor"
-      policy = "mdc-log-analytics-arc2-autoprovisioning-vm"
-    }
   }
 }
 
-# Enabling vm extensions - Log Analytics for arc and vulnerability assessment
+# Enabling vm extensions - Vulnerability assessment
 data "azurerm_policy_definition" "vm_policies" {
   for_each = contains(var.mdc_plans_list, "VirtualMachines") ? local.virtual_machine_policies : {}
 
@@ -51,17 +37,6 @@ resource "azurerm_subscription_policy_assignment" "vm" {
   identity {
     type = "SystemAssigned"
   }
-
-  depends_on = [
-    azurerm_security_center_subscription_pricing.asc_plans["VirtualMachines"]
-  ]
-}
-
-# Enabling vm extensions - Log Analytics for vm
-resource "azurerm_security_center_auto_provisioning" "auto_provisioning" {
-  count = contains(var.mdc_plans_list, "VirtualMachines") ? 1 : 0
-
-  auto_provision = "On"
 
   depends_on = [
     azurerm_security_center_subscription_pricing.asc_plans["VirtualMachines"]


### PR DESCRIPTION
This PR removes the Log Analytics agent as it is now on the deprecation path. 

For more information, refer to the issue [Log Analytics auto provisioning is deprecated #92](https://github.com/Azure/terraform-azure-mdc-defender-plans-azure/issues/92)