### PR TITLE
Delete azurerm_security_center_auto_provisioning from SQL Server VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,6 @@ No modules.
 | [azurerm_role_assignment.va_auto_provisioning_containers_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.va_auto_provisioning_la_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.va_auto_provisioning_vm_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_security_center_auto_provisioning.la_auto_provisioning](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_auto_provisioning) | resource |
 | [azurerm_security_center_setting.setting_mcas](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_setting) | resource |
 | [azurerm_security_center_subscription_pricing.asc_plans](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_subscription_pricing) | resource |
 | [azurerm_subscription_policy_assignment.container](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subscription_policy_assignment) | resource |

--- a/extensions_sql_server_virtual_machines.tf
+++ b/extensions_sql_server_virtual_machines.tf
@@ -45,17 +45,6 @@ resource "azurerm_subscription_policy_assignment" "sql" {
   ]
 }
 
-# Enabling extension - Log Analytics for vm
-resource "azurerm_security_center_auto_provisioning" "la_auto_provisioning" {
-  count = local.sql_server_virtual_machines_enabled ? 1 : 0
-
-  auto_provision = "On"
-
-  depends_on = [
-    azurerm_security_center_subscription_pricing.asc_plans["SqlServerVirtualMachines"]
-  ]
-}
-
 # Enabling Log Analytics Roles
 data "azurerm_role_definition" "la_roles" {
   for_each = local.sql_server_virtual_machines_enabled ? local.log_analytics_roles : {}


### PR DESCRIPTION
Remove the Azure Log Analytics auto-provisioning resource from the SQL Server virtual machines.